### PR TITLE
Adding nikto

### DIFF
--- a/nikto/Dockerfile
+++ b/nikto/Dockerfile
@@ -1,0 +1,36 @@
+FROM fedora
+LABEL maintainer="security@lists.fedoraproject.org"
+
+RUN useradd -c 'nikto' -m -s /sbin/nologin nikto
+RUN dnf upgrade -y && \
+    dnf install -y \
+        git \
+        perl-libwhisker2 \
+        openssl-perl \
+        perl-RPC-XML \
+        perl-XMLRPC-Lite \
+        perl-Net-SSLeay \
+        perl-Time-HiRes \
+        perl-bignum \
+        perl-JSON-PP && \
+    dnf clean all
+
+WORKDIR /tmp
+RUN git clone https://github.com/sullo/nikto.git && \
+    cd nikto && \
+    rm -rf devdocs program/docs documentation README.md && \
+    mv program /usr/share/nikto && \
+    cd /usr/share/nikto && \
+    rm -rf /tmp/nikto && \
+    mv nikto.conf /etc/nikto.conf && \
+    mv nikto.pl /usr/bin/nikto && \
+    echo "EXECDIR=/usr/share/nikto" >> /etc/nikto.conf
+
+## Uninstall unnecessary packages.
+RUN dnf erase -y git && \
+    dnf clean all
+
+WORKDIR /
+USER nikto
+CMD ["-config", "/etc/nikto.conf"]
+ENTRYPOINT ["nikto"]


### PR DESCRIPTION
Running with no arguments:
```
$ docker run nikto
+ ERROR: No host specified
- Nikto v2.1.6
---------------------------------------------------------------------------

       -config+            Use this config file
       -Display+           Turn on/off display outputs
       -dbcheck            check database and other key files for syntax errors
       -Format+            save file (-o) format
       -Help               Extended help information
       -host+              target host
       -id+                Host authentication to use, format is id:pass or id:pass:realm
       -list-plugins       List all available plugins
       -output+            Write output to this file
       -nossl              Disables using SSL
       -no404              Disables 404 checks
       -Plugins+           List of plugins to run (default: ALL)
       -port+              Port to use (default 80)
       -root+              Prepend root value to all requests, format is /directory
       -ssl                Force ssl mode on port
       -Tuning+            Scan tuning
       -timeout+           Timeout for requests (default 10 seconds)
       -update             Update databases and plugins from CIRT.net
       -Version            Print plugin and database versions
       -vhost+             Virtual host (for Host header)
                + requires a value

        Note: This is the short help output. Use -H for full help text.
```


Scanning a site:
```
$ docker run nikto -host www.google.com
- Nikto v2.1.6
---------------------------------------------------------------------------
+ Target IP:          172.217.11.132
+ Target Hostname:    www.google.com
+ Target Port:        80
+ Start Time:         2017-11-09 18:08:18 (GMT0)
---------------------------------------------------------------------------
+ Server: gws
+ Cookie 1P_JAR created without the httponly flag
+ The X-Content-Type-Options header is not set. This could allow the user agent to render the content of the site in a different fashion to the MIME type
+ No CGI Directories found (use '-C all' to force check all possible dirs)
+ Server banner has changed from 'gws' to 'sffe' which may suggest a WAF, load balancer or proxy is in place
+ Entry '/search/about/' in robots.txt returned a non-forbidden or redirect HTTP code (200)
+ Entry '/search/howsearchworks/' in robots.txt returned a non-forbidden or redirect HTTP code (200)
+ Entry '/groups/' in robots.txt returned a non-forbidden or redirect HTTP code (302)
+ Entry '/index.html?' in robots.txt returned a non-forbidden or redirect HTTP code (200)
+ Entry '/?/' in robots.txt returned a non-forbidden or redirect HTTP code (200)
...
...```