### PR TITLE
Adding cewl

### DIFF
--- a/cewl/Dockerfile
+++ b/cewl/Dockerfile
@@ -1,0 +1,36 @@
+FROM fedora
+LABEL maintainer="security@lists.fedoraproject.org"
+
+RUN useradd -c 'cewl' -m -s /sbin/nologin cewl
+RUN dnf upgrade -y && \
+    dnf install -y \
+        git \
+        gcc \
+        redhat-rpm-config \
+        zlib-devel \
+        ruby-devel \
+        rubygem-bundler \
+        rubygems \
+        rubygem-json && \
+    dnf clean all
+
+WORKDIR /tmp
+RUN git clone https://github.com/digininja/CeWL.git && \
+    mv CeWL /usr/share/cewl && \
+    cd /usr/share/cewl && \
+    mv cewl.rb cewl && \
+    bundle install && \
+    gem source -c
+
+## Uninstall unnecessary packages.
+RUN dnf erase -y \
+        git \
+        gcc \
+        redhat-rpm-config \
+        rubygem-bundler && \
+    dnf clean all
+
+WORKDIR /usr/share/cewl
+USER cewl
+CMD ["-h"]
+ENTRYPOINT ["./cewl"]


### PR DESCRIPTION
```
docker run --rm -it cewl
CeWL 5.4 (Break Out) Robin Wood (robin@digi.ninja) (https://digi.ninja/)
Usage: cewl [OPTION] ... URL
	--help, -h: show help
	--keep, -k: keep the downloaded file
	--depth x, -d x: depth to spider to, default 2
	--min_word_length, -m: minimum word length, default 3
	--offsite, -o: let the spider visit other sites
	--write, -w file: write the output to the file
	--ua, -u user-agent: user agent to send
	--no-words, -n: don't output the wordlist
	--meta, -a include meta data
	--meta_file file: output file for meta data
	--email, -e include email addresses
	--email_file file: output file for email addresses
	--meta-temp-dir directory: the temporary directory used by exiftool when parsing files, default /tmp
	--count, -c: show the count for each word found

	Authentication
		--auth_type: digest or basic
		--auth_user: authentication username
		--auth_pass: authentication password

	Proxy Support
		--proxy_host: proxy host
		--proxy_port: proxy port, default 8080
		--proxy_username: username for proxy, if required
		--proxy_password: password for proxy, if required

	Headers
		--header, -H: in format name:value - can pass multiple

	--verbose, -v: verbose
	--debug: extra debug information

	URL: The site to spider.

```